### PR TITLE
Add Recently Closed Tabs Feature

### DIFF
--- a/background.js
+++ b/background.js
@@ -11,6 +11,9 @@ let settings = {
 let tabVisitHistory = {};
 let lastActiveTab = null;
 
+// Track recently closed tabs for recovery
+let recentlyClosedTabs = [];
+
 // Initialize extension
 chrome.runtime.onInstalled.addListener(() => {
   console.log('Tab Cleaner extension installed');
@@ -20,6 +23,9 @@ chrome.runtime.onInstalled.addListener(() => {
   
   // Initialize activity tracking for existing tabs
   initializeExistingTabs();
+  
+  // Load recently closed tabs
+  loadRecentlyClosedTabs();
   
   // Set up keepalive
   setupKeepalive();
@@ -33,6 +39,7 @@ chrome.runtime.onStartup.addListener(() => {
   console.log('Tab Cleaner extension started');
   loadSettingsAndCreateAlarm();
   initializeExistingTabs();
+  loadRecentlyClosedTabs();
   setupKeepalive();
   updateTabCountBadge();
 });
@@ -115,6 +122,34 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     console.log('Manual badge update requested');
     updateTabCountBadge();
     return false;
+  }
+  
+  if (message.action === 'getRecentlyClosedTabs') {
+    console.log('Getting recently closed tabs...');
+    sendResponse({ recentlyClosedTabs: recentlyClosedTabs });
+    return false;
+  }
+  
+  if (message.action === 'reopenTab') {
+    console.log('Reopening tab:', message.tabId);
+    reopenClosedTab(message.tabId).then(newTab => {
+      sendResponse({ success: true, newTab: newTab });
+    }).catch(error => {
+      console.error('Error reopening tab:', error);
+      sendResponse({ success: false, error: error.message });
+    });
+    return true; // Keep message channel open for async response
+  }
+  
+  if (message.action === 'closeTabWithTracking') {
+    console.log('Manually closing tab with tracking:', message.tabId);
+    closeTabWithTracking(message.tabId).then(result => {
+      sendResponse({ success: true, result: result });
+    }).catch(error => {
+      console.error('Error closing tab with tracking:', error);
+      sendResponse({ success: false, error: error.message });
+    });
+    return true; // Keep message channel open for async response  
   }
   
   console.log('Unknown message action:', message.action);
@@ -432,6 +467,121 @@ async function saveTabActivityToStorage() {
   }
 }
 
+// Add tab to recently closed list
+async function addToRecentlyClosedTabs(tab, reason = 'auto-closed') {
+  try {
+    const closedTabInfo = {
+      id: `closed_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
+      title: tab.title,
+      url: tab.url,
+      favIconUrl: tab.favIconUrl,
+      windowId: tab.windowId,
+      closedAt: Date.now(),
+      reason: reason,
+      inactiveTime: tabActivity[tab.id] ? Date.now() - tabActivity[tab.id] : 0
+    };
+
+    recentlyClosedTabs.unshift(closedTabInfo);
+    
+    // Keep only last 50 closed tabs
+    if (recentlyClosedTabs.length > 50) {
+      recentlyClosedTabs = recentlyClosedTabs.slice(0, 50);
+    }
+    
+    // Remove tabs older than 7 days
+    const sevenDaysAgo = Date.now() - (7 * 24 * 60 * 60 * 1000);
+    recentlyClosedTabs = recentlyClosedTabs.filter(tab => tab.closedAt > sevenDaysAgo);
+    
+    // Save to storage
+    await chrome.storage.local.set({
+      'recentlyClosedTabs': recentlyClosedTabs
+    });
+    
+    console.log(`Added tab to recently closed: ${tab.title}`);
+  } catch (error) {
+    console.error('Error saving recently closed tab:', error);
+  }
+}
+
+// Load recently closed tabs from storage
+async function loadRecentlyClosedTabs() {
+  try {
+    const result = await chrome.storage.local.get(['recentlyClosedTabs']);
+    if (result.recentlyClosedTabs) {
+      recentlyClosedTabs = result.recentlyClosedTabs;
+      console.log(`Loaded ${recentlyClosedTabs.length} recently closed tabs`);
+    }
+  } catch (error) {
+    console.error('Error loading recently closed tabs:', error);
+  }
+}
+
+// Reopen a recently closed tab
+async function reopenClosedTab(closedTabId) {
+  try {
+    const tabIndex = recentlyClosedTabs.findIndex(tab => tab.id === closedTabId);
+    if (tabIndex === -1) {
+      throw new Error('Tab not found in recently closed list');
+    }
+    
+    const closedTab = recentlyClosedTabs[tabIndex];
+    
+    // Create new tab
+    const newTab = await chrome.tabs.create({
+      url: closedTab.url,
+      windowId: closedTab.windowId
+    });
+    
+    // Initialize activity for the reopened tab
+    tabActivity[newTab.id] = Date.now();
+    tabVisitHistory[newTab.id] = Date.now();
+    
+    // Remove from recently closed list
+    recentlyClosedTabs.splice(tabIndex, 1);
+    await chrome.storage.local.set({
+      'recentlyClosedTabs': recentlyClosedTabs
+    });
+    
+    await saveTabActivityToStorage();
+    
+    console.log(`Reopened tab: ${closedTab.title}`);
+    return newTab;
+  } catch (error) {
+    console.error('Error reopening tab:', error);
+    throw error;
+  }
+}
+
+// Close a tab with tracking (for manual closes from options page)
+async function closeTabWithTracking(tabId) {
+  try {
+    // Get tab info before closing
+    const tab = await chrome.tabs.get(tabId);
+    
+    // Save tab info to recently closed
+    await addToRecentlyClosedTabs(tab, 'manually-closed');
+    
+    // Close the tab
+    await chrome.tabs.remove(tabId);
+    
+    // Clean up tracking data
+    delete tabActivity[tabId];
+    delete tabVisitHistory[tabId];
+    
+    if (lastActiveTab === tabId) {
+      lastActiveTab = null;
+    }
+    
+    await saveTabActivityToStorage();
+    
+    console.log(`Manually closed tab with tracking: ${tab.title}`);
+    return { tabId, title: tab.title };
+  } catch (error) {
+    console.error('Error closing tab with tracking:', error);
+    throw error;
+  }
+}
+
 // Ensure all current tabs are being tracked
 async function ensureAllTabsTracked() {
   try {
@@ -525,6 +675,10 @@ async function cleanupInactiveTabs() {
       if (inactiveTime > inactiveThreshold) {
         try {
           console.log(`Closing tab: ${tab.title} (${inactiveMinutes}min inactive)`);
+          
+          // Save tab info before closing
+          await addToRecentlyClosedTabs(tab, 'auto-closed');
+          
           await chrome.tabs.remove(tab.id);
           delete tabActivity[tab.id];
           delete tabVisitHistory[tab.id];

--- a/options.js
+++ b/options.js
@@ -215,13 +215,22 @@ async function closeTab(tabId) {
     try {
         console.log('Attempting to close tab:', tabId);
 
-        // Close the tab
-        await chrome.tabs.remove(tabId);
+        // Close the tab with tracking via background script
+        const response = await new Promise((resolve) => {
+            chrome.runtime.sendMessage({ 
+                action: 'closeTabWithTracking', 
+                tabId: tabId 
+            }, resolve);
+        });
 
-        // Update the all-time tabs removed counter
-        await incrementTabsRemovedCount(1);
+        if (response && response.success) {
+            // Update the all-time tabs removed counter
+            await incrementTabsRemovedCount(1);
 
-        console.log('Successfully closed tab:', tabId);
+            console.log('Successfully closed tab:', response.result.title);
+        } else {
+            throw new Error(response?.error || 'Failed to close tab');
+        }
 
         // Refresh the tab list to show updated state
         await refreshTabsList();

--- a/popup.html
+++ b/popup.html
@@ -140,6 +140,82 @@
         .creator-link:hover {
             color: #007bff;
         }
+
+        .recently-closed-section {
+            background: white;
+            border-radius: 8px;
+            padding: 16px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+            margin-bottom: 12px;
+        }
+
+        .section-title {
+            font-size: 14px;
+            font-weight: 600;
+            color: #2c3e50;
+            margin: 0 0 12px 0;
+        }
+
+        .closed-tab-item {
+            display: flex;
+            align-items: center;
+            padding: 8px 0;
+            border-bottom: 1px solid #f1f3f4;
+        }
+
+        .closed-tab-item:last-child {
+            border-bottom: none;
+        }
+
+        .closed-tab-favicon {
+            width: 16px;
+            height: 16px;
+            margin-right: 8px;
+            flex-shrink: 0;
+        }
+
+        .closed-tab-info {
+            flex-grow: 1;
+            min-width: 0;
+        }
+
+        .closed-tab-title {
+            font-size: 12px;
+            color: #2c3e50;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            margin: 0 0 2px 0;
+        }
+
+        .closed-tab-details {
+            font-size: 10px;
+            color: #6c757d;
+        }
+
+        .reopen-btn {
+            background-color: #28a745;
+            color: white;
+            border: none;
+            padding: 4px 8px;
+            border-radius: 3px;
+            font-size: 10px;
+            cursor: pointer;
+            margin-left: 8px;
+            flex-shrink: 0;
+        }
+
+        .reopen-btn:hover {
+            background-color: #218838;
+        }
+
+        .no-recent-tabs {
+            text-align: center;
+            color: #6c757d;
+            font-size: 12px;
+            font-style: italic;
+            padding: 12px 0;
+        }
     </style>
 </head>
 <body>
@@ -191,6 +267,15 @@
 
         <div class="reset-container">
             <button class="reset-btn" id="resetBtn">Reset Statistics</button>
+        </div>
+    </div>
+
+    <div id="recentlyClosedContainer" style="display: none;">
+        <div class="recently-closed-section">
+            <h3 class="section-title">Recently Closed Tabs</h3>
+            <div id="recentlyClosedList">
+                <div class="no-recent-tabs">No recently closed tabs</div>
+            </div>
         </div>
     </div>
 

--- a/popup.js
+++ b/popup.js
@@ -38,6 +38,9 @@ async function loadStatistics() {
         // Load persistent statistics
         await loadPersistentStats();
 
+        // Load recently closed tabs
+        await loadRecentlyClosedTabs();
+
         showStats();
 
     } catch (error) {
@@ -185,6 +188,7 @@ function showStats() {
     document.getElementById('loadingMessage').style.display = 'none';
     document.getElementById('errorMessage').style.display = 'none';
     document.getElementById('statsContainer').style.display = 'block';
+    document.getElementById('recentlyClosedContainer').style.display = 'block';
 }
 
 // Show error state
@@ -192,4 +196,123 @@ function showError() {
     document.getElementById('loadingMessage').style.display = 'none';
     document.getElementById('errorMessage').style.display = 'block';
     document.getElementById('statsContainer').style.display = 'none';
+}
+
+// Load recently closed tabs
+async function loadRecentlyClosedTabs() {
+    try {
+        const response = await chrome.runtime.sendMessage({ action: 'getRecentlyClosedTabs' });
+        const recentlyClosedTabs = response.recentlyClosedTabs || [];
+        
+        displayRecentlyClosedTabs(recentlyClosedTabs);
+    } catch (error) {
+        console.error('Error loading recently closed tabs:', error);
+        displayRecentlyClosedTabs([]);
+    }
+}
+
+// Display recently closed tabs in the UI
+function displayRecentlyClosedTabs(tabs) {
+    const container = document.getElementById('recentlyClosedList');
+    
+    if (!tabs || tabs.length === 0) {
+        container.innerHTML = '<div class="no-recent-tabs">No recently closed tabs</div>';
+        return;
+    }
+    
+    // Show only the most recent 5 tabs
+    const recentTabs = tabs.slice(0, 5);
+    
+    // Clear container and build elements properly
+    container.innerHTML = '';
+    
+    recentTabs.forEach(tab => {
+        const timeSinceClosed = formatTimeSince(tab.closedAt);
+        const fallbackFavicon = 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><rect width="16" height="16" fill="%23ccc"/></svg>';
+        
+        // Create elements properly to avoid HTML injection issues
+        const itemDiv = document.createElement('div');
+        itemDiv.className = 'closed-tab-item';
+        
+        const favicon = document.createElement('img');
+        favicon.className = 'closed-tab-favicon';
+        favicon.src = tab.favIconUrl || fallbackFavicon;
+        favicon.alt = '';
+        favicon.onerror = function() { this.src = fallbackFavicon; };
+        
+        const infoDiv = document.createElement('div');
+        infoDiv.className = 'closed-tab-info';
+        
+        const titleDiv = document.createElement('div');
+        titleDiv.className = 'closed-tab-title';
+        titleDiv.textContent = tab.title;
+        titleDiv.title = tab.title;
+        
+        const detailsDiv = document.createElement('div');
+        detailsDiv.className = 'closed-tab-details';
+        detailsDiv.textContent = `${timeSinceClosed} • ${tab.reason}`;
+        
+        const reopenBtn = document.createElement('button');
+        reopenBtn.className = 'reopen-btn';
+        reopenBtn.textContent = 'Reopen';
+        reopenBtn.onclick = () => reopenTab(tab.id);
+        
+        // Assemble the structure
+        infoDiv.appendChild(titleDiv);
+        infoDiv.appendChild(detailsDiv);
+        itemDiv.appendChild(favicon);
+        itemDiv.appendChild(infoDiv);
+        itemDiv.appendChild(reopenBtn);
+        container.appendChild(itemDiv);
+    });
+}
+
+// Reopen a closed tab
+async function reopenTab(tabId) {
+    try {
+        const response = await chrome.runtime.sendMessage({ 
+            action: 'reopenTab', 
+            tabId: tabId 
+        });
+        
+        if (response.success) {
+            console.log('Tab reopened successfully');
+            // Refresh the recently closed tabs list
+            await loadRecentlyClosedTabs();
+            // Also refresh statistics
+            await loadTabStatistics();
+        } else {
+            console.error('Failed to reopen tab:', response.error);
+            alert('Failed to reopen tab: ' + response.error);
+        }
+    } catch (error) {
+        console.error('Error reopening tab:', error);
+        alert('Error reopening tab. Please try again.');
+    }
+}
+
+// Format time since closed
+function formatTimeSince(timestamp) {
+    const now = Date.now();
+    const diff = now - timestamp;
+    const minutes = Math.floor(diff / (1000 * 60));
+    const hours = Math.floor(diff / (1000 * 60 * 60));
+    const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+    
+    if (days > 0) {
+        return `${days} day${days > 1 ? 's' : ''} ago`;
+    } else if (hours > 0) {
+        return `${hours} hour${hours > 1 ? 's' : ''} ago`;
+    } else if (minutes > 0) {
+        return `${minutes} minute${minutes > 1 ? 's' : ''} ago`;
+    } else {
+        return 'Just now';
+    }
+}
+
+// Escape HTML to prevent XSS
+function escapeHtml(text) {
+    const div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
 }


### PR DESCRIPTION
## Summary
• Track and display recently closed tabs with one-click reopen functionality
• Support for both auto-closed and manually-closed tabs
• Clean UI integrated into existing popup design

## Features Added
• **Tab Tracking**: Automatically saves tab info before closing (title, URL, favicon, timestamp, reason)
• **Popup Display**: New section showing last 5 recently closed tabs with reopen buttons  
• **Manual Close Integration**: Tabs closed from options page are also tracked
• **Smart Cleanup**: Automatic removal of tabs older than 7 days, max 50 items stored
• **Safe DOM Handling**: Prevents HTML injection with proper element creation

## Technical Details
• New `recentlyClosedTabs` array in background.js with persistence to chrome.storage.local
• Added message handlers: `getRecentlyClosedTabs`, `reopenTab`, `closeTabWithTracking`
• Enhanced popup UI with new CSS styles and JavaScript functionality
• Updated options.js to use tracking-aware tab closing

## Test Plan
- [ ] Close tabs automatically via timeout - verify they appear in popup
- [ ] Close tabs manually from options page - verify they appear in popup  
- [ ] Reopen tabs from popup - verify they restore to correct window
- [ ] Verify old tabs are cleaned up after 7 days
- [ ] Test with various tab types (pinned, audio, chrome://, etc.)

🤖 Generated with [Claude Code](https://claude.ai/code)