### PR TITLE
Add GitHub Actions workflow for Chrome Web Store publishing

### DIFF
--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -1,0 +1,92 @@
+name: Publish to Chrome Web Store
+
+on:
+  push:
+    tags:
+      - 'v*'  # Trigger on version tags like v1.0.5
+  workflow_dispatch:  # Allow manual trigger
+    inputs:
+      publish:
+        description: 'Publish to store (true) or just upload as draft (false)'
+        required: true
+        default: 'false'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '18'
+        cache: 'npm'
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Validate extension
+      run: npm run validate
+
+    - name: Build extension
+      run: npm run build
+
+    - name: Get version from tag
+      id: version
+      run: |
+        if [ "${{ github.event_name }}" = "push" ]; then
+          echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+        else
+          echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Create release zip
+      run: |
+        cd dist
+        zip -r ../tab-cleaner-v${{ steps.version.outputs.version }}.zip .
+
+    - name: Upload to Chrome Web Store
+      uses: mnao305/chrome-extension-upload@v5.0.0
+      with:
+        file-path: './tab-cleaner-v${{ steps.version.outputs.version }}.zip'
+        extension-id: ${{ secrets.CHROME_EXTENSION_ID }}
+        client-id: ${{ secrets.CHROME_CLIENT_ID }}
+        client-secret: ${{ secrets.CHROME_CLIENT_SECRET }}
+        refresh-token: ${{ secrets.CHROME_REFRESH_TOKEN }}
+        publish: ${{ github.event_name == 'push' || github.event.inputs.publish == 'true' }}
+
+    - name: Upload release artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: extension-v${{ steps.version.outputs.version }}
+        path: './tab-cleaner-v${{ steps.version.outputs.version }}.zip'
+        retention-days: 30
+
+    - name: Create GitHub Release
+      if: github.event_name == 'push'
+      uses: softprops/action-gh-release@v1
+      with:
+        files: './tab-cleaner-v${{ steps.version.outputs.version }}.zip'
+        generate_release_notes: true
+        draft: false
+        prerelease: false
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Notify success
+      if: success()
+      run: |
+        echo "🎉 Extension successfully uploaded to Chrome Web Store!"
+        echo "Version: v${{ steps.version.outputs.version }}"
+        if [ "${{ github.event_name }}" = "push" ] || [ "${{ github.event.inputs.publish }}" = "true" ]; then
+          echo "Status: Published for review"
+        else
+          echo "Status: Uploaded as draft"
+        fi


### PR DESCRIPTION
## Summary
- Adds automated publishing workflow for Chrome Web Store
- Triggers on version tags or manual dispatch
- Validates and builds extension before upload
- Creates GitHub releases for tagged versions

## Test plan
- [ ] Verify workflow file syntax is correct
- [ ] Test manual dispatch with draft mode
- [ ] Test version tag publishing (after secrets are configured)

🤖 Generated with [Claude Code](https://claude.ai/code)